### PR TITLE
hack docs/conf.py for readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,14 @@ for mod_name in MOCK_MODULES:
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 sys.path.insert(0, os.path.abspath('../..'))
+# The following is a hack to handle the case that the repo name is not qnd.
+# This happens, for example, at readthedocs.org, which includes version
+# numbers in the top level repo directory name.
+top_level_name = os.path.basename(os.path.abspath(".."))
+if top_level_name != "qnd":
+    import importlib
+    importlib.import_module(top_level_name)
+    sys.modules["qnd"] = sys.modules[top_level_name]
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Here is a hack to docs/conf.py that I believe will fix the problem with the sphinx automodule page building at qnd.readthedocs.org.  It allows for the top level directory of the working repo to have a name other than "qnd".  It works for both python2 and python3 sphinx.
