### PR TITLE
Change pdbdump to make all index origins 1 rather than 0.

### DIFF
--- a/pdbdump.py
+++ b/pdbdump.py
@@ -169,7 +169,7 @@ def flusher(f, root):
     _dump_group(f, prefix, False, root, blocks)
     f.write(b'\n')
     # Finally comes the extras section.
-    f.write(b'Offset:0\n')  # Default index origin always 0.
+    f.write(b'Offset:1\n')  # Default index origin always 1 to match yorick.
     # Alignment: char, *, short, integer, long, float, double, \n
     f.write(b'Alignment:' + tobytes([1] + aligns[:6]) + b'\n')
     f.write(b'Struct-Alignment:' + _byt(chart.structal) + b'\n')
@@ -264,7 +264,8 @@ def _dump_group(f, prefix, islist, group, blocks):
             shape = (1,) + (shape or ())
         if shape:
             size = prod(shape)
-            shape = b'\x01'.join(b'0\x01' + _byt(s)
+            # Set all index origins to 1 to match yorick.
+            shape = b'\x01'.join(b'1\x01' + _byt(s)
                                   for s in reversed(shape)) + b'\x01'
         else:
             size = 1


### PR DESCRIPTION
This fixes the complaint that basis gives qnd-created arrays 0-index origin.  The underlying problem is that basis/pact/libpdb does not provide a method for ignoring the index origin specified in files, which is needed for languages like numpy, Fortran, C, and many others which do not support the concept of selectable index origin.  The most compatible workaround is to assign 1-origin indices to all arrays, which is what yorick did.

This patch changes both the index origins in the symtab entry for each array currently in the file, and the Offset: extra which libpdb will apply as the default for any arrays created in the future.
