### PR TITLE
fixed bug in append and r+ mode for pdbf, ncf modules

### DIFF
--- a/pdbparse.py
+++ b/pdbparse.py
@@ -615,6 +615,7 @@ def parser(handle, root, index=0):
         # structure chart -- effectively symtab just gives length of chart.
         raise IOError("PDB file chart must precede symtab")
     f.seek(chart)
+    handle.declared(handle.zero_address() | int64(chart), None, 0)
     chart_contents = f.read(symtab - chart)  # "chart" is PDB type table
     symtab_contents = f.read()
     if version == 3:


### PR DESCRIPTION
This fixes a bug in 'a' and 'r+' mode reported by Jay Salmonson.  Multiple problems have been fixed, which potentially break compatibility with PDB file families produced by lasnex - hence this commit should be tested to be sure it can still open such file families before merging it.  (I cannot test this.)

The semantics of appending new records to file families is complicated, and this patch resolves an ambiguity: Namely, it is now the case that when you open any file with records in it in append or r+ mode, the first new record you write will go into a new file even if the final file of the original family was not full (according to maxsize).  That is, none of the files in the existing family will be modified.  This is different from a non-record file, which will always add new variables in the original file, thus modifying the original.