### PR TITLE
Fixed frontend.py to correctly read lists, h5f.py to write lists

### DIFF
--- a/qnd/h5f.py
+++ b/qnd/h5f.py
@@ -129,7 +129,7 @@ class H5Group(object):
         if dtype == dict:
             return H5Group(h5item.create_group(name))
         if dtype == list:
-            return QnDList(h5item.create_group(name), 1)
+            return QnDList(H5Group(h5item.create_group(name)), 1)
         if dtype is None or (shape and not all(shape)):
             h5item[name] = npdtype('u1') if dtype is None else dtype
             item = h5item[name]


### PR DESCRIPTION
Also, frontend.py ignores np.VisibleDeprecationWarning that will eventually require major changes in how the _categorize function is implemented.

These changes fix bugs preventing the h5f module from writing a list to the file (tries to invoke isgroup method on something  that isn't a qnd Group), and preventing any backend from indexing a QList object or calling it to retrieve the whole list (gives index out of bounds error).

The deprecation warning is a far more serious problem.  Writing lists will break when the deprecated functionality is actually removed.
