### PR TITLE
Fixed error writing complex or strct to PDB file

### DIFF
--- a/qnd/pdbdump.py
+++ b/qnd/pdbdump.py
@@ -156,12 +156,12 @@ def flusher(f, root):
     for name, struct in itemsof(structs):
         size = struct[0].itemsize
         f.write(name + b'\x01' + _byt(size) + b'\x01')
-        for tname, shape in itemsof(struct[3]):
+        for mname, (tname, shape) in itemsof(struct[3]):
             if shape:
                 shape = b'[' + b','.join(_byt(s) for s in shape) + b']'
             else:
                 shape = b''
-            f.write(tname + b' ' + name + shape + b'\x01')
+            f.write(tname + b' ' + mname + shape + b'\x01')
         f.write(b'\n')
     f.write(b'\x02\n')
     # Next comes the symbol table.

--- a/qnd/pdbparse.py
+++ b/qnd/pdbparse.py
@@ -158,6 +158,9 @@ class PDBChart(object):
         else:
             fields = dtype.fields
             names = dtype.names
+            n = self.nanons
+            self.nanons += 1
+            name = '_anon_{}'.format(n).encode('latin1')
         if not names:
             order = self.byteorder
             if not order:
@@ -194,10 +197,8 @@ class PDBChart(object):
                 if al > align:
                     align = al
                 desc[nm.encode('latin1')] = typename, shape
+            desc = size, desc
             adder = self.add_struct
-        n = self.nanons
-        self.nanons += 1
-        name = '_anon_{}'.format(n).encode('latin1')
         stype = adder(name, desc)
         return stype, align, name
 


### PR DESCRIPTION
The PDB backend was unable to write complex or struct data.  This repairs the pdbparse and pdbdump modules to fix these bugs.