### PR TITLE
New PDB features: attributes, None, 0-length arrays working, general feature: simple class instances working

### DIFF
--- a/qnd/pdbf.py
+++ b/qnd/pdbf.py
@@ -118,7 +118,7 @@ def openpdb(filename, mode='r', auto=1, hooks=None, **kwargs):
             name = handle.filename(i)
             if not i:
                 raise IOError("Fatal errors opening PDB file "
-                              "".format(name))
+                              "{}".format(name))
             handle.open(i-1)
             warn("file family stopped by incompatible {}".format(name))
     if not n and order:

--- a/qnd/pdbparse.py
+++ b/qnd/pdbparse.py
@@ -1095,6 +1095,8 @@ def _endparse(root, structal, haspointers, primtypes, structs, symtab, errors,
     undefined = set()
     groups = {b'': root}
     addr0 = root.handle.zero_address()
+    attributes = OrderedDict()
+    attr_address = None;
     for name, (addr, tname, shape) in itemsof(symtab):
         defblock = deferred.get(name)
         if name.startswith(b'/'):
@@ -1132,12 +1134,45 @@ def _endparse(root, structal, haspointers, primtypes, structs, symtab, errors,
             name = name.decode('latin1')
         stype, dtype, align, _ = dtype  # from primitives[] or structs[]
         dtype = dtype, stype, align, tname
-        grp._leaf_declare(name, dtype, shape, addr)
+        if name.startswith(":") :
+            if attr_address is None or addr < attr_address:
+                attr_address = addr
+            attributes[name[1:]] = dtype, shape, addr
+        else:
+            grp._leaf_declare(name, dtype, shape, addr)
     if undefined:
         errors.append("undefined types: {}".format(undefined))
-
+    if len(attributes):
+        root.has_attributes = True
+        varname, vname, var = "", "", root
+        for aname, (dtype, shape, addr) in itemsof(attributes):
+            prevname = varname
+            varname = aname.rsplit(":", 1)
+            bad = len(varname) < 2
+            if not bad:
+                varname, name = varname  # name is attribute name
+                if varname != prevname:  # otherwise grp and vname unchanged
+                    path = varname.split(":")
+                    vname = path.pop()
+                    grp = root
+                    for gname in path:
+                        grp = grp.lookup(gname)
+                        if grp.islist() == 2:
+                            grp = var.parent()
+                        elif not grp.isgroup():
+                            bad = True
+                            break
+            if bad:
+                errors.append(
+                    "cannot find attribute: {}".format(aname))
+                continue
+            grp._read_attr(vname, name, dtype[0], shape, addr)
+        # Ensure that attributes are overwritten if file is extended:
+        handle = root.handle
+        handle.declared(handle.zero_address() | int64(attr_address), None, 0)
     if errors:
         # Can filter this by module name.
+        print(errors)
         warn("{} errors parsing PDB metadata".format(len(errors)))
 
 


### PR DESCRIPTION
Variable attributes are now saved and restored in PDB files.  All attributes are written as variables with names beginning with ":" on the root group, but always just before the PDB chart and symtab, and they are clobbered if you extend the file, and rewritten next time it flushes like all other metadata.  Variables can now have the value None.  And zero-length ndarrays (that is with one or more length 0 dimensions) can now be saved and restored as expected.  These features always worked in HDF files; now they work in PDB files as well.

Finally, both PDB and HDF files can now save and restore class instances, at least in simple cases.  Both Ellipsis and slice objects can be saved and restored using this mechanism, along with many other kinds of python objects.  The QnD API partially implements the pickling API (__getstate__, __getnewargs__, etc.).